### PR TITLE
Fix crash when returning to the previous screen.

### DIFF
--- a/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
+++ b/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
@@ -57,8 +57,10 @@
         if (NJK_IS_RUNNING_IOS7) {
             // fade bar buttons
             UIColor *tintColor = self.navigationController.navigationBar.tintColor;
-            CGFloat *components = (CGFloat *)CGColorGetComponents(tintColor.CGColor);
-            self.navigationController.navigationBar.tintColor = [UIColor colorWithRed:components[0] green:components[1] blue:components[2] alpha:alpha];
+            if (tintColor) {
+                CGFloat *components = (CGFloat *)CGColorGetComponents(tintColor.CGColor);
+                self.navigationController.navigationBar.tintColor = [UIColor colorWithRed:components[0] green:components[1] blue:components[2] alpha:alpha];
+            }
         }
 
     }];


### PR DESCRIPTION
Crash When you return to the previous screen when you are viewing controlled by UIWebViewDelegate.

Example:

``` objc
- (void)webViewDidStartLoad:(UIWebView *)webView
{
    [self showNavigationBar:NO];
    [self showToolbar:NO];
}
```

`self.navigationController` is null sometimes. I added a null judgment for that.
