### PR TITLE
Fixing issue on forward delegate attribute

### DIFF
--- a/NJKScrollFullScreen/NJKScrollFullScreen.m
+++ b/NJKScrollFullScreen/NJKScrollFullScreen.m
@@ -28,6 +28,11 @@ NJKScrollDirection detectScrollDirection(currentOffsetY, previousOffsetY)
 
 @implementation NJKScrollFullScreen
 
+- (void)dealloc {
+    //Somehow this is still not set to nil in some cases
+    _forwardTarget = nil;
+}
+
 - (id)initWithForwardTarget:(id)forwardTarget
 {
     self = [super init];


### PR DESCRIPTION
Fixes crash in UIKit by calling dereferenced forward delegate. unsafe_unretained sets delegate to nil to prevent crashing.

Example stack trace from crash
1   UIKit                                0x331618bd -[UIScrollView(UIScrollViewInternal) _notifyDidScroll] + 62
2   UIKit                                0x32ede18d -[UIScrollView setContentOffset:] + 602
3   UIKit                                0x32f8bec9 -[UITableView setContentOffset:] + 334
4   UIKit                                0x33162833 -[UIScrollView(UIScrollViewInternal) _adjustContentOffsetIfNecessary] + 1396
5   UIKit                                0x32f915ff -[UIScrollView(UIScrollViewInternal) _stopScrollingNotify:pin:tramplingDragFlags:] + 416
6   UIKit                                0x32f91457 -[UIScrollView(UIScrollViewInternal) _stopScrollingNotify:pin:] + 28
7   UIKit                                0x32f9140f -[UIScrollView removeFromSuperview] + 28
8   UIKit                                0x32ebf9b3 -[UIView dealloc] + 364
