### PR TITLE
Fixed broken UINavigationBar tintColor

### DIFF
--- a/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
+++ b/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
@@ -64,8 +64,7 @@
             // fade bar buttons
             UIColor *tintColor = self.navigationController.navigationBar.tintColor;
             if (tintColor) {
-                CGFloat *components = (CGFloat *)CGColorGetComponents(tintColor.CGColor);
-                self.navigationController.navigationBar.tintColor = [UIColor colorWithRed:components[0] green:components[1] blue:components[2] alpha:alpha];
+                self.navigationController.navigationBar.tintColor = [tintColor colorWithAlphaComponent:alpha];
             }
         }
     }];


### PR DESCRIPTION
Sometimes `UINavigationBar`'s `tintColor` became broken. Because `CGColorGetComponents` returned not only 4 value. I fixed this problem with `colorWithAlphaComponent` instead of `CGColorGetComponents`.
