### PR TITLE
nil out tableView delegate on dealloc

### DIFF
--- a/DemoApp/ViewController.m
+++ b/DemoApp/ViewController.m
@@ -14,6 +14,22 @@
 
 @implementation ViewController
 
+- (void)dealloc
+{
+    // If tableView is scrolling as this VC is being dealloc'd
+    // it continues to send messages (scrollViewDidScroll:) to its delegate.
+    // This is fine if the delegate will outlive tableView (e.g. this VC would.)
+    // However, if the delegate is an instance that may be dealloc'd
+    // before the tableView
+    // (i.e. _scrollProxy may be dealloc'd prior to tableView being dealloc'd)
+    // the tableView will send messages to its delegate,
+    // which is defined with an "assign" (i.e. unsafe_unretained) property.
+    // This is a msgSend to non-nil'ed, invalid memory leading to a crash.
+    // If or when UIScrollView's delegate is referred to with "weak" rather
+    // than "assign", this can and should be removed.
+    self.tableView.delegate = nil;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];


### PR DESCRIPTION
Please advise as to in-code-commenting style.
Further, this may not necessarily be an issue with a UITableViewController's default UITableView, but we have certainly observed this issue when a UITableView was added to a UIViewController's view property.
###### 

If tableView is scrolling as this VC is being dealloc'd
it continues to send messages (scrollViewDidScroll:) to its delegate.
This is fine if the delegate will outlive tableView (e.g. this VC would.)
However, if the delegate is an instance that may be dealloc'd
before the tableView
(i.e. _scrollProxy may be dealloc'd prior to tableView being dealloc'd)
the tableView will send messages to its delegate,
which is defined with an "assign" (i.e. unsafe_unretained) property.
This is a msgSend to non-nil'ed, invalid memory leading to a crash.
If or when UIScrollView's delegate is referred to with "weak" rather
than "assign", this can and should be removed.
