### PR TITLE
Forwarding conformsToProtocol method to delegate

### DIFF
--- a/NJKScrollFullScreen/NJKScrollFullScreen.m
+++ b/NJKScrollFullScreen/NJKScrollFullScreen.m
@@ -189,4 +189,13 @@ NJKScrollDirection detectScrollDirection(currentOffsetY, previousOffsetY)
     return ret;
 }
 
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol
+{
+    BOOL ret = [super conformsToProtocol:aProtocol];
+    if (!ret) {
+        ret = [_forwardTarget conformsToProtocol:aProtocol];
+    }
+    return ret;
+}
+
 @end


### PR DESCRIPTION
Fix crash when using custom collection view layout. (e.g. CHTCollectionViewDelegateWaterfallLayout).
https://github.com/chiahsien/CHTCollectionViewWaterfallLayout

It require conforming to unique protocol.
