### PR TITLE
Support incoming-call status bar height

### DIFF
--- a/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
+++ b/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
@@ -20,15 +20,29 @@
 {
     CGSize statuBarFrameSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = UIInterfaceOrientationIsPortrait(self.interfaceOrientation) ? statuBarFrameSize.height : statuBarFrameSize.width;
-    [self setNavigationBarOriginY:statusBarHeight animated:animated];
+
+    UIWindow *appKeyWindow = [UIApplication sharedApplication].keyWindow;
+    UIView *appBaseView = appKeyWindow.rootViewController.view;
+    CGRect viewControllerFrame =  [appBaseView convertRect:appBaseView.bounds toView:appKeyWindow];
+
+    CGFloat overwrapStatusBarHeight = statusBarHeight - viewControllerFrame.origin.y;
+
+    [self setNavigationBarOriginY:overwrapStatusBarHeight animated:animated];
 }
 
 - (void)hideNavigationBar:(BOOL)animated
 {
     CGSize statuBarFrameSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = UIInterfaceOrientationIsPortrait(self.interfaceOrientation) ? statuBarFrameSize.height : statuBarFrameSize.width;
+
+    UIWindow *appKeyWindow = [UIApplication sharedApplication].keyWindow;
+    UIView *appBaseView = appKeyWindow.rootViewController.view;
+    CGRect viewControllerFrame =  [appBaseView convertRect:appBaseView.bounds toView:appKeyWindow];
+
+    CGFloat overwrapStatusBarHeight = statusBarHeight - viewControllerFrame.origin.y;
+
     CGFloat navigationBarHeight = self.navigationController.navigationBar.frame.size.height;
-    CGFloat top = NJK_IS_RUNNING_IOS7 ? -navigationBarHeight + statusBarHeight : -navigationBarHeight;
+    CGFloat top = NJK_IS_RUNNING_IOS7 ? -navigationBarHeight + overwrapStatusBarHeight : -navigationBarHeight;
 
     [self setNavigationBarOriginY:top animated:animated];
 }
@@ -44,14 +58,21 @@
 {
     CGSize statuBarFrameSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = UIInterfaceOrientationIsPortrait(self.interfaceOrientation) ? statuBarFrameSize.height : statuBarFrameSize.width;
+
+    UIWindow *appKeyWindow = [UIApplication sharedApplication].keyWindow;
+    UIView *appBaseView = appKeyWindow.rootViewController.view;
+    CGRect viewControllerFrame =  [appBaseView convertRect:appBaseView.bounds toView:appKeyWindow];
+
+    CGFloat overwrapStatusBarHeight = statusBarHeight - viewControllerFrame.origin.y;
+
     CGRect frame = self.navigationController.navigationBar.frame;
     CGFloat navigationBarHeight = frame.size.height;
 
-    CGFloat topLimit = NJK_IS_RUNNING_IOS7 ? -navigationBarHeight + statusBarHeight : -navigationBarHeight;
-    CGFloat bottomLimit = statusBarHeight;
+    CGFloat topLimit = NJK_IS_RUNNING_IOS7 ? -navigationBarHeight + overwrapStatusBarHeight : -navigationBarHeight;
+    CGFloat bottomLimit = overwrapStatusBarHeight;
 
     frame.origin.y = fmin(fmax(y, topLimit), bottomLimit);
-    CGFloat alpha = MAX(1 - (statusBarHeight - frame.origin.y) / statusBarHeight, kNearZero);
+    CGFloat alpha = MAX(1 - (overwrapStatusBarHeight - frame.origin.y) / overwrapStatusBarHeight, kNearZero);
     [UIView animateWithDuration:animated ? 0.1 : 0 animations:^{
         self.navigationController.navigationBar.frame = frame;
         NSUInteger index = 0;


### PR DESCRIPTION
Status bar is became wider by got incoming call. It makes window frame height smaller. In this situation, window height is 548px and status bar is 40px. Therefore, Navigation bar area has more 20px height. 

Currently `UIViewController+NJKFullScreenSupport` represent like below screenshot.
![ios apr 11 2014 2 44 27 pm](https://cloud.githubusercontent.com/assets/113420/2850089/8eff8840-d0f2-11e3-8ec4-6249ec2f3bc8.png)

This patch add incomming-call status bar support.
![ios apr 11 2014 2 34 02 pm](https://cloud.githubusercontent.com/assets/113420/2849924/2d4a41fe-d0ec-11e3-943c-6f81bf8f44bc.png)
