### PR TITLE
Resume bars when app backs to foreground

### DIFF
--- a/DemoApp/Base.lproj/Main.storyboard
+++ b/DemoApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="pH6-8N-gIx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="pH6-8N-gIx">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>
     <scenes>
         <!--View Controller - UITableView-->

--- a/DemoApp/ViewController.m
+++ b/DemoApp/ViewController.m
@@ -28,6 +28,8 @@
     // If or when UIScrollView's delegate is referred to with "weak" rather
     // than "assign", this can and should be removed.
     self.tableView.delegate = nil;
+
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)viewDidLoad
@@ -44,6 +46,8 @@
     self.tableView.delegate = (id)_scrollProxy; // cast for surpress incompatible warnings
 
     _scrollProxy.delegate = self;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resetBars) name:UIApplicationWillEnterForegroundNotification object:nil]; // resume bars when back to forground from other apps
 
     if (!IS_RUNNING_IOS7) {
         // support full screen on iOS 6
@@ -89,6 +93,13 @@
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         [self.refreshControl endRefreshing];
     });
+}
+
+- (void)resetBars
+{
+    [_scrollProxy reset];
+    [self showNavigationBar:NO];
+    [self showToolbar:NO];
 }
 
 #pragma mark -


### PR DESCRIPTION
iOS resumes UINavigationBar when app go back to foreground from background. It cause white navigation bar striped title color.

![ios may 7 2014 12 16 43 pm](https://cloud.githubusercontent.com/assets/113420/2898164/11b9f00c-d596-11e3-86bb-af665c6f4dd9.png)

This patch is modified DemoApp to resume bars manually when app backs to foreground.
