### PR TITLE
Fixed a problem when using `-showTabBar:` in iPad started in landscape mode

### DIFF
--- a/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
+++ b/NJKScrollFullScreen/UIViewController+NJKFullScreenSupport.m
@@ -166,9 +166,9 @@
     CGFloat viewHeight = UIInterfaceOrientationIsPortrait(self.interfaceOrientation) ? viewSize.height : viewSize.width;
     CGFloat topLimit = viewHeight - toolBarHeight;
     CGFloat bottomLimit = viewHeight;
-    
+
     frame.origin.y = fmin(fmax(y, topLimit), bottomLimit); // limit over moving
-    
+
     [UIView animateWithDuration:animated ? 0.1 : 0 animations:^{
         self.tabBarController.tabBar.frame = frame;
     }];


### PR DESCRIPTION
Highly possibly it's a bug in UIKit that when you access the view from the TabBarController, you got a fixed view size discarded the orientation info.
