### PR TITLE
add support delegates to prevent error message in swift.

### DIFF
--- a/NJKScrollFullScreen/NJKScrollFullScreen.h
+++ b/NJKScrollFullScreen/NJKScrollFullScreen.h
@@ -8,7 +8,7 @@
 
 @protocol NJKScrollFullscreenDelegate;
 
-@interface NJKScrollFullScreen : NSObject<UIScrollViewDelegate>
+@interface NJKScrollFullScreen : NSObject<UIScrollViewDelegate, UITableViewDelegate, UIWebViewDelegate>
 
 @property (nonatomic, weak) id<NJKScrollFullscreenDelegate> delegate;
 


### PR DESCRIPTION
This is to prevent this error message in swift: ![screen shot 2014-12-03 at 1 23 49 am](https://cloud.githubusercontent.com/assets/5866/5278149/12cd3c02-7a8b-11e4-88b3-bab2757549f9.png)

not sure this is a better way to get around it tho.
